### PR TITLE
Update BDA main category to remove doubled links

### DIFF
--- a/bda/b.txt
+++ b/bda/b.txt
@@ -24,5 +24,4 @@ AI can be used inside simulations or to steer workflows, while data science can 
 * [[skill-tree:bda:4:b]]
 * [[skill-tree:bda:5:b]]
 * [[skill-tree:bda:6:b]]
-* [[skill-tree:bda:6:b]]
 * [[skill-tree:bda:7:b]]


### PR DESCRIPTION
There was a link doubled for BDA6 on the BDA main category page. This is only a problem for the WIKI, not the tree. But this was also on the API, so this should be fixed.